### PR TITLE
eaf-pdf-mark-fontsize -> eaf-pdf-marker-fontsize

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -564,7 +564,7 @@ class PdfPage(fitz.Page):
             self._mark_search_annot_list = []
 
     def mark_jump_link_tips(self, letters):
-        fontsize, = get_emacs_vars(["eaf-pdf-mark-fontsize"])
+        fontsize, = get_emacs_vars(["eaf-pdf-marker-fontsize"])
         cache_dict = {}
         if self.page.firstLink:
             links = self.page.getLinks()

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -108,8 +108,8 @@ Non-nil means don't invert images."
   :type 'boolean
   :group 'eaf-pdf-viewer)
 
-(defcustom eaf-pdf-mark-fontsize 8
-  "The fontsize used by pdf mark."
+(defcustom eaf-pdf-marker-fontsize 8
+  "The fontsize used by pdf marker."
   :type 'integer
   :group 'eaf-pdf-viewer)
 


### PR DESCRIPTION
for eaf.el use marker instead of mark.