### PR TITLE
option to enable/disable notification of file changed

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -358,7 +358,10 @@ class PdfDocument(fitz.Document):
             except:
                 return
 
-            message_to_emacs("Detected that %s has been changed. Refreshing buffer..." %path)
+            notify, = get_emacs_vars(["eaf-pdf-notify-file-changed"])
+            if notify:
+                message_to_emacs("Detected that %s has been changed. Refreshing buffer..." %path)
+
             self.watch_callback()
             # if the file have been renew save, file_changed_watcher will remove the path form monitor list.
             if len(self.file_changed_wacher.files()) == 0 :

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -78,6 +78,11 @@
   :type 'boolean
   :group 'eaf-pdf-viewer)
 
+(defcustom eaf-pdf-notify-file-changed t
+  "If it is t, pdf-viewer will notify that the displayed pdf file is changed. Otherwise the pdf-viewer buffer will be refreshed silently."
+  :type 'boolean
+  :group 'eaf-pdf-viewer)
+
 (defcustom eaf-pdf-dark-mode "follow"
   "Whether to enable inverted color rendering when starting the pdf-viewer app.
 


### PR DESCRIPTION
Hi,

I created this PR to include an option `eaf-pdf-notify-file-changed` which can control whether EAF pdf-viewer will notify users when pdf files are changed.

This option is useful when EAF pdf-viewer is used as the backend PDF viewer of AuxTex: I can set `eaf-pdf-notify-file-changed` to `nil` so that EAF will keep silent and compilation messages from AuxTex will not be overwritten by EAF.

Can you advise if it can be merged back to your repo?

Thanks!