### PR TITLE
make Emacs stay in LaTeX buffer when doing synctex backward

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -1541,6 +1541,7 @@ class PdfViewerWidget(QWidget):
                 self.handle_translate_word()
             elif event.button() == Qt.LeftButton and self.synctex_page_num:
                 self.handle_synctex_backward_edit()
+                return True
 
         return False
 


### PR DESCRIPTION
Hi,

I created this PR to fix the bug https://github.com/emacs-eaf/eaf-pdf-viewer/issues/13.
Now EAF pdf-viewer can make Emacs stay in the LaTeX buffer