### PR TITLE
support manually reloading PDF document

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -996,6 +996,15 @@ class PdfViewerWidget(QWidget):
         return self.scale * self.page_height * self.page_total_number - self.rect().height()
 
     @interactive
+    def reload_document(self):
+        self.document = PdfDocument(fitz.open(self.url))
+        # recompute width, height, total number since the file might be modified
+        self.page_width = self.document.get_page_width()
+        self.page_height = self.document.get_page_height()
+        self.page_total_number = self.document.pageCount
+        message_to_emacs("Reloaded document!")
+
+    @interactive
     def toggle_read_mode(self):
         if self.read_mode == "fit_to_customize":
             self.read_mode = "fit_to_width"

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -152,6 +152,7 @@ Non-nil means don't invert images."
     ("C-s" . "search_text_forward")
     ("C-r" . "search_text_backward")
     ("x" . "close_buffer")
+    ("r" . "reload_document")
     ("C-<right>" . "rotate_clockwise")
     ("C-<left>" . "rotate_counterclockwise")
     ("M-h" . "add_annot_highlight")


### PR DESCRIPTION
Hi,

I created this PR to allow PDF files can be manually reloaded by using the key `r`.

This feature is useful when sometimes the auto-reloading feature doesn't work properly. It happens quite often with me when I prepare slides using LaTeX beamer: sometimes when exporting LaTeX to PDF file, new pages are added but EAF pdf-viewer didn't render the new file correctly.

So, in this PR, I also need to update the page_width, height, and total page number to make sure the new file will be reloaded correctly.

Can you advise if this is reasonable and can be merged?

Thank you!