### PR TITLE
compute the current page number more precise, and add option to control showing page number directly on PDF page

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -902,15 +902,21 @@ class PdfViewerWidget(QWidget):
         else:
             painter.setPen(inverted_color((self.theme_foreground_color)))
 
-        # Draw progress.
-        progress_percent = int((self.start_page_index + 1) * 100 / self.page_total_number)
-        current_page = self.start_page_index + 1
-        painter.drawText(QRect(self.rect().x(),
-                               self.rect().y(),
-                               self.rect().width() - self.page_annotate_padding_right,
-                               self.rect().height() - self.page_annotate_padding_bottom),
-                         Qt.AlignRight | Qt.AlignBottom,
-                         "{0}% ({1}/{2})".format(progress_percent, current_page, self.page_total_number))
+        # Update mode-line-position
+        current_page = math.floor((self.start_page_index + self.last_page_index + 1) / 2)
+        eval_in_emacs("eaf--pdf-update-position", [current_page, self.page_total_number])
+
+        # Draw progress on page.
+        show_progress_on_page, = get_emacs_vars(["eaf-pdf-show-progress-on-page"])
+        if show_progress_on_page:
+            progress_percent = int((self.start_page_index + 1) * 100 / self.page_total_number)
+            painter.drawText(QRect(self.rect().x(),
+                                   self.rect().y(),
+                                   self.rect().width() - self.page_annotate_padding_right,
+                                   self.rect().height() - self.page_annotate_padding_bottom),
+                             Qt.AlignRight | Qt.AlignBottom,
+                             "{0}% ({1}/{2})".format(progress_percent, current_page, self.page_total_number))
+
 
     def build_context_wrap(f):
         def wrapper(*args):
@@ -1437,7 +1443,8 @@ class PdfViewerWidget(QWidget):
             self.scroll_offset = new_offset
             self.update()
 
-            eval_in_emacs("eaf--pdf-update-position", [self.start_page_index + 1, self.page_total_number])
+            current_page = math.floor((self.start_page_index + self.last_page_index + 1) / 2)
+            eval_in_emacs("eaf--pdf-update-position", [current_page, self.page_total_number])
 
     def update_horizontal_offset(self, new_offset):
         if self.horizontal_offset != new_offset:

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -83,6 +83,11 @@
   :type 'boolean
   :group 'eaf-pdf-viewer)
 
+(defcustom eaf-pdf-show-progress-on-page t
+  "If it is t, pdf-viewer will show progress (in percentage) and page number directly on the document."
+  :type 'boolean
+  :group 'eaf-pdf-viewer)
+
 (defcustom eaf-pdf-dark-mode "follow"
   "Whether to enable inverted color rendering when starting the pdf-viewer app.
 


### PR DESCRIPTION
Hi,

In this PR, I improved EAF pdf-viewer in points:

- Compute the current page more precise by the formula `math.floor((self.start_page_index + self.last_page_index + 1) / 2)`. Previously, the current page information ignore the fact about the last_page_index, hence it will be imprecise when the document is zoomed out to show many pages

- Add option to control showing page number on page `eaf-pdf-show-progress-on-page`. This is useful since currently the mode-line can also show the page number, then I can set `eaf-pdf-show-progress-on-page` to `nil` to hide the page infor on the PDF file.

Can you advise if these features can be merged?

Thank you!

