### PR TITLE
show an indicator of synchronized text from LaTeX to PDF

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -49,7 +49,6 @@ class AppBuffer(Buffer):
         self.delete_temp_file = arguments == "temp_pdf_file"
 
         self.synctex_info = [None, None, None]
-        self.synctex_timer = QTimer()
         if arguments.startswith("synctex_info"):
             synctex_info = arguments.split("=")[1].split(":")
             page_num = int(synctex_info[0])
@@ -59,9 +58,6 @@ class AppBuffer(Buffer):
 
         self.add_widget(PdfViewerWidget(url, QColor(buffer_background_color), buffer_id, self.synctex_info))
         self.buffer_widget.translate_double_click_word.connect(translate_text)
-
-        if arguments.startswith("synctex_info"):
-            self.synctex_timer.singleShot(5000, self.buffer_widget.reset_synctex_indicator)
 
         # Use thread to avoid slow down open speed.
         threading.Thread(target=self.record_open_history).start()
@@ -167,8 +163,6 @@ class AppBuffer(Buffer):
         self.buffer_widget.synctex_pos_x = float(synctex_info[1])
         self.buffer_widget.synctex_pos_y = float(synctex_info[2])
         self.buffer_widget.update()
-
-        self.synctex_timer.singleShot(5000, self.buffer_widget.reset_synctex_indicator)
         return ""
 
     def jump_to_percent(self):
@@ -942,6 +936,7 @@ class PdfViewerWidget(QWidget):
         painter.setBrush(fillColor)
         painter.setPen(borderColor)
         painter.drawPolygon(arrow)
+        QtCore.QTimer().singleShot(5000, self.reset_synctex_indicator)
         painter.restore()
 
     def reset_synctex_indicator(self):

--- a/buffer.py
+++ b/buffer.py
@@ -22,7 +22,7 @@
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QRect, QPoint, QEvent, QTimer, QFileSystemWatcher
 from PyQt5.QtGui import QColor, QPixmap, QImage, QFont, QCursor
-from PyQt5.QtGui import QPainter, QPolygon
+from PyQt5.QtGui import QPainter, QPolygon, QPalette
 from PyQt5.QtWidgets import QWidget
 from PyQt5.QtWidgets import QToolTip
 from core.buffer import Buffer
@@ -728,6 +728,12 @@ class PdfViewerWidget(QWidget):
 
         # Padding between pages.
         self.page_padding = 10
+
+        # Fill app background color
+        pal = self.palette()
+        pal.setColor(QPalette.Background, self.background_color)
+        self.setAutoFillBackground(True)
+        self.setPalette(pal)
 
         # Init font.
         self.page_annotate_padding_right = 10

--- a/buffer.py
+++ b/buffer.py
@@ -49,6 +49,7 @@ class AppBuffer(Buffer):
         self.delete_temp_file = arguments == "temp_pdf_file"
 
         self.synctex_info = [None, None, None]
+        self.synctex_timer = QTimer()
         if arguments.startswith("synctex_info"):
             synctex_info = arguments.split("=")[1].split(":")
             page_num = int(synctex_info[0])
@@ -59,8 +60,8 @@ class AppBuffer(Buffer):
         self.add_widget(PdfViewerWidget(url, QColor(buffer_background_color), buffer_id, self.synctex_info))
         self.buffer_widget.translate_double_click_word.connect(translate_text)
 
-        # if arguments.startswith("synctex_info"):
-        #     self.buffer_widget.QTimer.singleShot(5, self.buffer_widget.reset_synctex_indicator)
+        if arguments.startswith("synctex_info"):
+            self.synctex_timer.singleShot(5000, self.buffer_widget.reset_synctex_indicator)
 
         # Use thread to avoid slow down open speed.
         threading.Thread(target=self.record_open_history).start()
@@ -167,7 +168,7 @@ class AppBuffer(Buffer):
         self.buffer_widget.synctex_pos_y = float(synctex_info[2])
         self.buffer_widget.update()
 
-        QTimer.singleShot(5, self.buffer_widget.reset_synctex_indicator)
+        self.synctex_timer.singleShot(5000, self.buffer_widget.reset_synctex_indicator)
         return ""
 
     def jump_to_percent(self):

--- a/buffer.py
+++ b/buffer.py
@@ -155,12 +155,16 @@ class AppBuffer(Buffer):
 
     def jump_to_page_synctex(self, synctex_info):
         synctex_info = synctex_info.split(":")
-        widget = self.buffer_widget
-        widget.synctex_page_num = int(synctex_info[0])
-        widget.synctex_pos_x = float(synctex_info[1])
-        widget.synctex_pos_y = float(synctex_info[2])
-        widget.jump_to_page(widget.synctex_page_num)
-        widget.update()
+        page_num = int(synctex_info[0])
+        pos_x = float(synctex_info[1])
+        pos_y = float(synctex_info[2])
+
+        self.buffer_widget.synctex_page_num = page_num
+        self.buffer_widget.jump_to_page(page_num)
+
+        self.buffer_widget.synctex_pos_x = pos_x
+        self.buffer_widget.synctex_pos_y = pos_y
+        self.buffer_widget.update()
         return ""
 
     def jump_to_percent(self):
@@ -901,17 +905,17 @@ class PdfViewerWidget(QWidget):
 
             painter.drawPixmap(rect, qpixmap)
 
+            # Draw an indicator for Synctex position
+            if self.synctex_page_num == index + 1 and self.synctex_pos_y != None:
+                indicator_pos_y = self.synctex_pos_y * self.scale
+                self.draw_synctex_indicator(painter, 15, indicator_pos_y)
+
             render_y += render_height
 
         # Clean unused pixmap cache that avoid use too much memory.
         self.clean_unused_page_cache_pixmap()
 
         painter.restore()
-
-        # Draw an indicator for Synctex position
-        if self.synctex_pos_y and (self.synctex_pos_y > 0):
-            indicator_pos_y = self.synctex_pos_y * self.scale
-            self.draw_synctex_indicator(painter, 15, indicator_pos_y)
 
         # Render current page.
         painter.setFont(self.font)
@@ -980,8 +984,6 @@ class PdfViewerWidget(QWidget):
 
     @build_context_wrap
     def wheelEvent(self, event):
-        self.clear_synctex_indicator()
-
         if not event.accept():
             if event.angleDelta().y():
                 numSteps = event.angleDelta().y()


### PR DESCRIPTION
Hi,

I just implemented a simple version of the feature mentioned in this issue https://github.com/emacs-eaf/eaf-pdf-viewer/issues/6.
Now, EAF pdf-viewer can show the indicator when synchronizing from LaTeX to PDF file. 
Here is an illustration screenshot:

![synctex](https://user-images.githubusercontent.com/193967/133495798-27a77635-7302-4255-88f6-4f92401cc881.png)

Although the current indicator `===>` is quite basic since I'm not proficient in Python and PyQT, at least it can show quite precisely the text location on the PDF file.

Could you review the code if it is OK, and merge it when possible?

Thank you!


