### PR TITLE
support inline text annot

### DIFF
--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -119,8 +119,18 @@ Non-nil means don't invert images."
   :group 'eaf-pdf-viewer)
 
 (defcustom eaf-pdf-marker-fontsize 8
-  "The fontsize used by pdf marker."
+  "The font size used by pdf marker."
   :type 'integer
+  :group 'eaf-pdf-viewer)
+
+(defcustom eaf-pdf-inline-text-annot-fontsize 8
+  "The font size used by pdf inline text annot."
+  :type 'integer
+  :group 'eaf-pdf-viewer)
+
+(defcustom eaf-pdf-inline-text-annot-color "#ec3f00"
+  "The color used by pdf inline text annot."
+  :type 'string
   :group 'eaf-pdf-viewer)
 
 (defcustom eaf-pdf-viewer-keybinding
@@ -165,7 +175,9 @@ Non-nil means don't invert images."
     ("M-u" . "add_annot_underline")
     ("M-s" . "add_annot_squiggly")
     ("M-d" . "add_annot_strikeout_or_delete_annot")
-    ("M-e" . "add_annot_text_or_edit_annot")
+    ("M-t" . "add_annot_popup_text")
+    ("M-T" . "add_annot_inline_text")
+    ("M-e" . "edit_annot_text")
     ("M-p" . "toggle_presentation_mode")
     ("J" . "select_left_tab")
     ("K" . "select_right_tab")


### PR DESCRIPTION
Hi,

I created this PR to support inline text annotation, as mentioned in this issue: https://github.com/emacs-eaf/eaf-pdf-viewer/issues/23

In the code, I rename the current `text_annot` naming as `popup_text_annot` naming, and add a new naming `inline_text_annot` for the inline text annotation.

Here is the screenshot of how it looks like (it supports multiple-line inline text annot too!)

![annot](https://user-images.githubusercontent.com/193967/133873388-6eb1c5bc-340c-43f1-a3fc-46cc804a158b.png)

I also reassign keybindings a bit to make it more consistent:
- `M-t`: add popup text annot
- `M-T`: add inline text annot
- `M-e`: edit text annot (both)

Can you consider merging it back?

Thank you!
