### PR TITLE
always attempt to sync-tex backward

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -1672,7 +1672,7 @@ class PdfViewerWidget(QWidget):
             self.disable_inline_text_annot_mode()
             if event.button() == Qt.RightButton:
                 self.handle_translate_word()
-            elif event.button() == Qt.LeftButton and self.synctex_page_num:
+            elif event.button() == Qt.LeftButton:
                 self.handle_synctex_backward_edit()
                 return True
 


### PR DESCRIPTION
Hi,

Currently, the sync-tex backward feature is only enabled when the PDF is previously opened by a sync-tex forward command.

In this PR, I remove that condition check to allow it can work even when the PDF file is opened normally (like using `C-x C-f`)