### PR TITLE
print annotation editing messages only when PDF buffer is focused

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -798,8 +798,7 @@ class PdfViewerWidget(QWidget):
 
     def is_buffer_focused(self):
         try:
-            path_url = get_emacs_func_result("eaf-get-path-or-url", [])
-            return (self.url == path_url)
+            return get_emacs_func_result("eaf-get-path-or-url", []) == self.url
         except Exception:
             return False
 

--- a/buffer.py
+++ b/buffer.py
@@ -26,7 +26,7 @@ from PyQt5.QtGui import QPainter, QPolygon, QPalette
 from PyQt5.QtWidgets import QWidget
 from PyQt5.QtWidgets import QToolTip
 from core.buffer import Buffer
-from core.utils import touch, interactive, eval_in_emacs, message_to_emacs, open_url_in_new_tab, translate_text, atomic_edit, get_emacs_vars, get_emacs_config_dir
+from core.utils import touch, interactive, eval_in_emacs, message_to_emacs, open_url_in_new_tab, translate_text, atomic_edit, get_emacs_vars, get_emacs_func_result, get_emacs_config_dir
 import fitz
 import time
 import random
@@ -796,6 +796,13 @@ class PdfViewerWidget(QWidget):
         if self.synctex_page_num != None:
             self.jump_to_page(self.synctex_page_num)
 
+    def is_buffer_focused(self):
+        try:
+            path_url = get_emacs_func_result("eaf-get-path-or-url", [])
+            return (self.url == path_url)
+        except Exception:
+            return False
+
     @interactive
     def toggle_presentation_mode(self):
         '''
@@ -1488,7 +1495,6 @@ class PdfViewerWidget(QWidget):
             is_hover_tex_annot = False
             current_annot = None
 
-            # if self.is_focus():
             for annot in annots:
                 if fitz.Point(ex, ey) in annot.rect:
                     # message_to_emacs(annot.info["content"])
@@ -1506,7 +1512,7 @@ class PdfViewerWidget(QWidget):
 
             # update and print message only if changed
             if is_hover_annot != self.is_hover_annot:
-                if print_msg:
+                if print_msg and self.is_buffer_focused():
                     if not is_hover_annot:
                         eval_in_emacs("eaf--clear-message", [])
                     elif is_hover_tex_annot:


### PR DESCRIPTION
Hi,

I added a check `is_buffer_focused` to print the annotation editing messages only when a PDF buffer is focused.

Currently, I check this condition by comparing `buffer_url` maintained by the Python app and the `path_url` get from Emacs buffer.
(I tried `self.isActiveWindow` and `self.isFocus` before but the information they return isn't correct).

Can you take a look and merge if it is OK?

Thanks!