### PR TITLE
make stroke color of text highlight and underline annot customizable

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -797,7 +797,7 @@ class PdfViewerWidget(QWidget):
             self.jump_to_page(self.synctex_page_num)
 
     def is_buffer_focused(self):
-        # This check is slow, use only necessary
+        # This check is slow, use only when necessary
         try:
             return get_emacs_func_result("eaf-get-path-or-url", []) == self.url
         except Exception:

--- a/buffer.py
+++ b/buffer.py
@@ -797,6 +797,7 @@ class PdfViewerWidget(QWidget):
             self.jump_to_page(self.synctex_page_num)
 
     def is_buffer_focused(self):
+        # This check is slow, use only necessary
         try:
             return get_emacs_func_result("eaf-get-path-or-url", []) == self.url
         except Exception:
@@ -1342,10 +1343,18 @@ class PdfViewerWidget(QWidget):
 
             if annot_type == "highlight":
                 new_annot = page.addHighlightAnnot(quad_list)
+                color, = get_emacs_vars(["eaf-pdf-text-highlight-annot-color"])
+                qcolor = QColor(color)
+                new_annot.setColors(stroke=qcolor.getRgbF()[0:3])
+                new_annot.update()
             elif annot_type == "strikeout":
                 new_annot = page.addStrikeoutAnnot(quad_list)
             elif annot_type == "underline":
                 new_annot = page.addUnderlineAnnot(quad_list)
+                color, = get_emacs_vars(["eaf-pdf-text-underline-annot-color"])
+                qcolor = QColor(color)
+                new_annot.setColors(stroke=qcolor.getRgbF()[0:3])
+                new_annot.update()
             elif annot_type == "squiggly":
                 new_annot = page.addSquigglyAnnot(quad_list)
             elif annot_type == "text":

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -133,6 +133,16 @@ Non-nil means don't invert images."
   :type 'string
   :group 'eaf-pdf-viewer)
 
+(defcustom eaf-pdf-text-highlight-annot-color "#ffd815"
+  "The color used by pdf text highlighting annot."
+  :type 'string
+  :group 'eaf-pdf-viewer)
+
+(defcustom eaf-pdf-text-underline-annot-color "#11e32a"
+  "The color used by pdf text highlighting annot."
+  :type 'string
+  :group 'eaf-pdf-viewer)
+
 (defcustom eaf-pdf-viewer-keybinding
   '(("j" . "scroll_up")
     ("<down>" . "scroll_up")


### PR DESCRIPTION
Hi,

In this PR, I improve the text highlighting and underlining annotation features to make the stroke colors to be customizable 

This fixed the issue https://github.com/emacs-eaf/eaf-pdf-viewer/issues/32, and help users to be less confused between highlighted text and selected text.