### PR TITLE
only print message when the mouse cursor hovers annotations, but not selected texts

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -1518,7 +1518,7 @@ class PdfViewerWidget(QWidget):
             current_annot = None
 
             for annot in annots:
-                if fitz.Point(ex, ey) in annot.rect:
+                if annot.info["title"] and fitz.Point(ex, ey) in annot.rect:
                     is_hover_annot = True
                     current_annot = annot
                     opacity = 0.5


### PR DESCRIPTION
Hi,

This fixes the issue https://github.com/emacs-eaf/eaf-pdf-viewer/issues/33 where EAF pdf-viewer prints ""[M-d]Delete annot" when the mouse cursor hovers selected text.

I fixed it by simply checking that if the annot doesn't have a title, then it's a text selection and will not be highlighted