### PR TITLE
support undo/redo annot action

### DIFF
--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -184,6 +184,8 @@ Non-nil means don't invert images."
     ("M-w" . "copy_select")
     ("C-s" . "search_text_forward")
     ("C-r" . "search_text_backward")
+    ("C-/" . "undo_annot_action")
+    ("C-?" . "redo_annot_action")
     ("x" . "close_buffer")
     ("r" . "reload_document")
     ("C-<right>" . "rotate_clockwise")


### PR DESCRIPTION
Hi,

This is the PR that I implemented undo/redo for actions that add/delete annotations mentioned in https://github.com/emacs-eaf/eaf-pdf-viewer/issues/25.
The shortcut keys are `C-/` for undo and `C-?` for undo (standard shortcut keys in Emacs).

Could you take a look and review it?

Thanks!
