### PR TITLE
Adjusting cropbox reset to mediabox

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -600,7 +600,7 @@ class PdfPage(fitz.Page):
             d = get_page_text(self.page)("rawdict")
             # cancel the cropbox, if not, will cause the pixmap set cropbox
             # don't begin on top-left(0, 0), page display black margin
-            set_page_crop_box(self.page)(self.page.MediaBox)
+            set_page_crop_box(self.page)(fitz.Rect(self.page.MediaBox.x0,0,self.page.MediaBox.x1,self.page.MediaBox.y1-self.page.MediaBox.y0))
             return d
         else:
             return get_page_text(self.page)("rawdict")


### PR DESCRIPTION
Since the mediabox is in PDF coordinates to begin with, setting the cropbox by passing it that will do a transformation on the coordinates incorrectly (the set cropbox code does its own transformation of received PyMuPDF coordinates back into PDF coordinates). This update here does the transformation in eaf (which takes the mediabox in PDF coordinates and puts it into PyMuPDF coordinates) so that the set cropbox function can take those PyMuPDF coordinates and convert them back into PDF coordinates as it needs. I have tested this with a few assorted PDFs and haven't seen any hiccups or bad crops.