### PR TITLE
Fix API removed keyword 'hit_max' issue. Closes #68.

### DIFF
--- a/eaf_pdf_page.py
+++ b/eaf_pdf_page.py
@@ -26,7 +26,7 @@ from PyQt5.QtWidgets import QToolTip
 from core.utils import (message_to_emacs, get_emacs_vars)
 import fitz
 
-from eaf_pdf_utils import generate_random_key
+from eaf_pdf_utils import generate_random_key, support_hit_max
 
 def set_page_crop_box(page):
     if hasattr(page, "set_cropbox"):
@@ -288,7 +288,11 @@ class PdfPage(fitz.Page):
             self._mark_link_annot_list = []
 
     def mark_search_text(self, keyword):
-        quads_list = self.page.searchFor(keyword, hit_max=999, quads=True)
+        if support_hit_max:
+            quads_list = self.page.searchFor(keyword, hit_max=999, quads=True)
+        else:
+            quads_list = self.page.search_for(keyword, quads=True)
+
         if quads_list:
             for quads in quads_list:
                 annot = self.page.addHighlightAnnot(quads)

--- a/eaf_pdf_utils.py
+++ b/eaf_pdf_utils.py
@@ -47,3 +47,13 @@ def generate_random_key(count, letters):
             key_list.append(key)
             count -= 1
     return key_list
+
+def is_old_version(v, v_bound='1.18.2'):
+    from packaging import version
+
+    return version.parse(v) < version.parse(v_bound)
+
+
+import fitz
+
+support_hit_max = is_old_version(fitz.VersionBind)

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -33,7 +33,7 @@ import time
 import math
 
 from eaf_pdf_document import PdfDocument
-from eaf_pdf_utils import inverted_color
+from eaf_pdf_utils import inverted_color, support_hit_max
 from eaf_pdf_annot import AnnotAction
 
 def set_page_crop_box(page):
@@ -794,8 +794,13 @@ class PdfViewerWidget(QWidget):
         self.search_term = text
 
         self.search_text_index = 0
+
         for page_index in range(self.page_total_number):
-            quads_list = self.document.search_page_for(page_index, text, hit_max=999, quads=True)
+            if support_hit_max:
+                quads_list = self.document.search_page_for(page_index, text, hit_max=999, quads=True)
+            else:
+                quads_list = self.document.search_page_for(page_index, text, quads=True)
+
             if quads_list:
                 for index, quad in enumerate(quads_list):
                     search_text_offset = (page_index * self.page_height + quad.ul.y) * self.scale


### PR DESCRIPTION
This is an attempt to fix #68 while maintaining backward compatibility.

- If version >= 1.18.2, use API without `hit_max` keyword arg.
- Replace deprecated `searchFor` with `search_for` in new versions to remove deprecation warning in `*eaf*` buffer.

Feel free to make changes where you see fit.

Minimally tested on my machine with `qt5-legacy` branch. Should apply to `master` branch as well. (Since PyQt6 does not work for my `eaf-browser`, I don't have the environment to test on `master`. NOTE: exactly why my PR is requesting to merge to qt5-legacy branch)