### PR TITLE
fix pymupdf new api after 1.19.0 

### DIFF
--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -472,6 +472,25 @@ This function works best if paired with a fuzzy search package."
                          (with-temp-file pdf-history-file-path "")))))
     (if history-pdf (eaf-open history-pdf))))
 
+(defun eaf-pdf-delete-invalid-file-record-from-history ()
+  " delete invalid file record from eaf pdf history file"
+  (interactive)
+  (let* ((pdf-history-file-path
+          (concat eaf-config-location
+                  (file-name-as-directory "pdf")
+                  (file-name-as-directory "history")
+                  "log.txt"))
+         (history-pattern "^\\(.+\\)\\.pdf$")
+         (history-file-exists (file-exists-p pdf-history-file-path))
+         file-content)
+    (when history-file-exists
+        (setq file-content (f-read-text pdf-history-file-path))
+        (dolist (each-file (split-string file-content "\n" t))
+          (unless (file-exists-p each-file)
+            (setq file-content (replace-regexp-in-string (rx--to-expr (format! "%s\n"  each-file)) "" file-content))
+            (message "delete %s record from history" each-file)))
+        (f-write-text file-content 'utf-8 pdf-history-file-path))))
+
 (defun eaf-pdf-delete-pages (page-num)
   " Delete pdf pages
 1 => delete page 1

--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -32,6 +32,7 @@ import sys
 sys.path.append(os.path.dirname(__file__))
 
 from eaf_pdf_widget import PdfViewerWidget
+from eaf_pdf_utils import use_new_doc_name
 
 class SynctexInfo():
     def __init__(self, info):
@@ -289,7 +290,10 @@ class AppBuffer(Buffer):
 
     def get_toc(self):
         result = ""
-        toc = self.buffer_widget.document.getToC()
+        if use_new_doc_name:
+            toc = self.buffer_widget.document.get_toc()
+        else:
+            toc = self.buffer_widget.document.getToC()
         for line in toc:
             result += "{0}{1} {2}\n".format("".join("    " * (line[0] - 1)), line[1], line[2])
         return result

--- a/eaf_pdf_utils.py
+++ b/eaf_pdf_utils.py
@@ -50,10 +50,13 @@ def generate_random_key(count, letters):
 
 def is_old_version(v, v_bound='1.18.2'):
     from packaging import version
-
     return version.parse(v) < version.parse(v_bound)
 
+def is_doc_new_name(v, v_bound='1.19.0'):
+    from packaging import version
+    return version.parse(v) >= version.parse(v_bound)
 
 import fitz
 
 support_hit_max = is_old_version(fitz.VersionBind)
+use_new_doc_name = is_doc_new_name(fitz.VersionBind)


### PR DESCRIPTION
after 1.19.0 version  getToc() rename to get_toc(),  and I add  eaf-pdf-delete-invalid-file-record-from-history function to delete invalid history record