### PR TITLE
Support edit PDF table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,5 @@ Override this behavior
 | `J` | select_left_tab |
 | `K` | select_right_tab |
 | `o` | eaf-pdf-outline |
+| `O` | eaf-pdf-outline-edit |
 | `T` | toggle_trim_white_margin |

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -280,7 +280,7 @@ Non-nil means don't invert images."
 
 (defvar eaf-pdf-outline-edit-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap org-open-at-point] #'eaf-pdf-outline-edit-jump)
+    (define-key map [remap org-insert-heading-respect-content] #'eaf-pdf-outline-edit-jump)
     (define-key map [remap org-ctrl-c-ctrl-c] #'eaf-pdf-outline-edit-buffer-confirm)
     (define-key map [remap org-kill-note-or-show-branches] #'kill-buffer-and-window)
     map)

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -383,7 +383,9 @@ Non-nil means don't invert images."
   (let* ((raw-value (org-element-property :raw-value (org-element-at-point)))
          (page-num (and (string-match (rx (1+ num) string-end) raw-value) (match-string 0 raw-value)))
          )
-    (eaf-call-sync "execute_function_with_args" eaf--buffer-id "jump_to_page_with_num" (format "%s" page-num))))
+    (if page-num
+        (eaf-call-sync "execute_function_with_args" eaf--buffer-id "jump_to_page_with_num" (format "%s" page-num))
+      (error "Has no corresponding page number!"))))
 
 (defun eaf-pdf-outline-view ()
   "View the specific page."
@@ -699,7 +701,7 @@ This function works best if paired with a fuzzy search package."
                                       )
                                  (if page-num
                                      (list level (string-trim-right title) (string-to-number page-num))
-                                   (error "Title: %s has no corresponding page-num number!" title)))) t))
+                                   (error "Title: %s has no corresponding page number!" title)))) t))
          )
     (eaf-call-async "execute_function_with_args" eaf--buffer-id "edit_outline_confirm" payload)))
 

--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -367,3 +367,16 @@ class AppBuffer(Buffer):
 
     def fetch_marker_callback(self):
         return list(map(lambda x: x.lower(), self.buffer_widget.jump_link_key_cache_dict.keys()))
+
+    def get_toc_to_edit (self):
+        result = ""
+        if use_new_doc_name:
+            toc = self.buffer_widget.document.get_toc()
+        else:
+            toc = self.buffer_widget.document.getToC()
+        for line in toc:
+            result += "{0} {1} {2}\n".format("".join("*" * line[0]), line[1], line[2])
+        return result
+
+    def edit_outline_confirm(self, payload):
+        self.buffer_widget.edit_outline_confirm(payload)

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -1386,3 +1386,8 @@ class PdfViewerWidget(QWidget):
         ex, ey, page_index = self.get_cursor_absolute_position()
         if page_index is not None:
             eval_in_emacs("eaf-pdf-synctex-backward-edit", [self.url, page_index + 1, ex, ey])
+
+    def edit_outline_confirm(self, payload):
+        self.document.set_toc(payload)
+        self.document.saveIncr()
+        message_to_emacs("Updated PDF Table of Contents successfully.")


### PR DESCRIPTION
In eaf-pdf-viewer hit upper case 'O' to activate eaf-pdf-outline-edit-mode.
The existed table of contents will be got from current PDF file and inserted to eaf-pdf-outline-edit-buffer.
So you can edit the TOC buffer and save it back to TOC of PDF.

In eaf-pdf-outline-edit-mode, 
- Use 'C-c C-c' to confirm editing and save the modification to PDF file.
- Use 'C-c C-k' to quit the mode.
- Hit 'C-return' to jump.

The eaf-pdf-outline-edit-mode is derived from Org-mode.
```
* 主要管理人员的设置 6
** 主要管理人员的一般设置要求 6
```
![image](https://user-images.githubusercontent.com/20676402/181813974-066f0150-7817-4829-9836-9b9bc6c41664.png)

- Use the number of Org mode style headline which starts with star '*' to control TOC hierarchy(level).
- One star '*' means the most top level of TOC, two star '**' means the second top level of TOC, and so on.
- A space is needed between the star '*' and the title '主要管理人员的设置' of TOC.
- In the end of Org mode style headline is page number, a space is needed between the title  '主要管理人员的设置'  and page number '6'.

