### PR TITLE
improve zoom fit to text width

### DIFF
--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -171,6 +171,7 @@ Non-nil means don't invert images."
     ("=" . "zoom_in")
     ("-" . "zoom_out")
     ("w" . "zoom_fit_text_width")
+    ("W" . "zoom_close_to_text_width")
     ("g" . "scroll_to_begin")
     ("G" . "scroll_to_end")
     ("p" . "jump_to_page")

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -616,7 +616,16 @@ class PdfViewerWidget(QWidget):
         self.read_mode = "fit_to_customize"
         page_index = self.start_page_index
         text_width = self.document._document_page_clip.width
-        self.scale_to(self.rect().width() * 0.99 / text_width)
+        self.scale_to(self.rect().width() * 0.95 / text_width)
+        self.scroll_center_horizontal()
+        self.update()
+
+    @interactive
+    def zoom_close_to_text_width(self):
+        self.read_mode = "fit_to_customize"
+        page_index = self.start_page_index
+        text_width = self.document._document_page_clip.width
+        self.scale_to(self.rect().width() * 0.8 / text_width)
         self.scroll_center_horizontal()
         self.update()
 


### PR DESCRIPTION
Hi, 

The current function `zoom-fit-text-width` does not keep any space on the right margin of the pdf page, like the below screenshot.

![Screenshot_2022-09-16_01-59-02](https://user-images.githubusercontent.com/193967/190478072-f847558e-fc9c-48e1-a853-79a5cc6a1a92.png)

So, I updated the Zoom ratio of `zoom-fit-text-width` to 0.95 and create a new function `zoom-close-to-text-width` with the zoom ratio 0.8, like the below screenshots.

Can you consider merging this PR?

Thanks!

- The new `zoom-fit-text-width`:

![Screenshot_2022-09-16_02-01-08](https://user-images.githubusercontent.com/193967/190478442-7c33eec4-6e03-4c2b-94ce-94390a4ed5df.png)

- The function `zoom-close-to-text-width`

![Screenshot_2022-09-16_02-01-34](https://user-images.githubusercontent.com/193967/190478524-222e6e12-b8b8-4054-afa4-7e1a0fe21b6c.png)

