### PR TITLE
make background transparent when PDF is created from MS Word/Powerpoint

### DIFF
--- a/eaf_pdf_page.py
+++ b/eaf_pdf_page.py
@@ -188,6 +188,13 @@ class PdfPage(fitz.Page):
             
         pixmap = get_page_pixmap(self.page)(matrix=fitz.Matrix(scale, scale), alpha=True)
 
+        # make background transparent
+        sample_color = pixmap.pixel(0,0)
+        if sample_color[3] == 255:
+            pixmap = self.make_background_transparent(pixmap, sample_color[:3])
+        elif sample_color[3] == 0:
+            pixmap = self.make_background_transparent(pixmap, (255,255,255))
+
         if invert:
             pixmap_invert_irect(pixmap)(pixmap.irect)
 
@@ -249,6 +256,12 @@ class PdfPage(fitz.Page):
             return None, True
 
         return None, False
+
+    def make_background_transparent(self, pixmap, opaque_color):
+        pixalpha = fitz.Pixmap(None, pixmap)
+        alpha = pixalpha.samples
+        pixmap.set_alpha(alpha, 1, opaque=opaque_color)
+        return pixmap
 
     def with_invert_exclude_image(self, scale, pixmap):
         # steps:


### PR DESCRIPTION
Hi,

I created this PR to transform background of PDF to transparent if it was previously colored (PDF created by MS Word/PowerPoint is colored by white color).

Here are screenshots in inverted mode of PDF files where some diagrams are created by Power Point.

- Before PR: when PDF is colored by white color, in the inverted mode, the background become black:
![pdf-1](https://user-images.githubusercontent.com/193967/219871730-03ffec7b-f9a0-4ef1-9472-775c423a11e3.png)

- After my PR, the background is transparent:
![pdf-2](https://user-images.githubusercontent.com/193967/219871736-2c39d9c5-27b5-4aa9-ab75-aeaa2370d91e.png)

Can you review and merge if it's useful?

Thanks!