### PR TITLE
add missing fields for the jump link indicator feature

### DIFF
--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -108,6 +108,8 @@ class PdfViewerWidget(QWidget):
 
         #jump link
         self.is_jump_link = False
+        self.link_page_num = None
+        self.link_page_offset_y = None
         self.jump_link_key_cache_dict = {}
 
         # hover link


### PR DESCRIPTION
I forgot to add these two fields in the previous PR for the jump link feature.

Fixed in this PR.