### PR TITLE
draw more precise indicator when jumping by hyperref or synctex

### DIFF
--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -231,7 +231,8 @@ class AppBuffer(Buffer):
 
     def jump_to_page_synctex(self, info):
         self.buffer_widget.synctex_info.update(info)
-        self.buffer_widget.jump_to_page(self.buffer_widget.synctex_info.page_num)
+        synctex = self.buffer_widget.synctex_info
+        self.buffer_widget.jump_to_page(synctex.page_num, synctex.pos_y)
         self.buffer_widget.update()
         return ""
 


### PR DESCRIPTION
Hi,

I improved the indicator drawing to indicate a more precise location for both clicking on a hyperref link and synctex (previously, only the synctex indicator is drawn precisely).

Can you consider merging this PR?

Thanks!