### PR TITLE
only restart the timer to reload a file if it exits

### DIFF
--- a/eaf_pdf_document.py
+++ b/eaf_pdf_document.py
@@ -96,9 +96,9 @@ class PdfDocument(fitz.Document):
                 self.watch_callback(url)
             self.file_changed_timer.stop()
         except Exception:
-            self.file_changed_timer.start()
-            message_to_emacs("Failed to reload PDF file!")
-
+            if os.path.exists(url):
+                self.file_changed_timer.start()
+                message_to_emacs("Failed to reload PDF file: " + url)
 
     def cache_page(self, index, page):
         self._page_cache_dict[index] = page

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -241,7 +241,7 @@ class PdfViewerWidget(QWidget):
         try:
             self.document = PdfDocument(fitz.open(url))    # type: ignore
         except Exception:
-            message_to_emacs("Failed to load PDF file!")
+            message_to_emacs("Failed to load PDF file: " + url)
             return
 
         # recompute width, height, total number since the file might be modified


### PR DESCRIPTION
Hi,

Currently, when a PDF that is opened in EAF PDF Viewer is deleted or renamed, then EAF-PDF-Viewer will constantly display the message `Failed to reload PDF file!`

I fixed this issue by only restarting the timer to reload the PDF file if that file exists.

Can you consider merging this PR?

Thanks!