### PR TITLE
only refine background in the invert mode

### DIFF
--- a/eaf_pdf_page.py
+++ b/eaf_pdf_page.py
@@ -187,14 +187,14 @@ class PdfPage(fitz.Page):
 
         pixmap = get_page_pixmap(self.page)(matrix=fitz.Matrix(scale, scale), alpha=True)
 
-        # make background transparent
-        sample_color = pixmap.pixel(0,0)
-        if sample_color[3] == 255:
-            pixmap = self.make_background_transparent(pixmap, sample_color[:3])
-        elif sample_color[3] == 0:
-            pixmap = self.make_background_transparent(pixmap, (255,255,255))
-
         if invert:
+            # make background transparent
+            sample_color = pixmap.pixel(0,0)
+            if sample_color[3] == 255:
+                pixmap = self.make_background_transparent(pixmap, sample_color[:3])
+            elif sample_color[3] == 0:
+                pixmap = self.make_background_transparent(pixmap, (255,255,255))
+
             pixmap_invert_irect(pixmap)(pixmap.irect)
 
         if not invert_image and invert:


### PR DESCRIPTION
Hi,

Currently, the PDF background is always made transparent even when the PDF file is viewed in the normal mode. This might affect the display of PDF files that have color backgrounds.

So, I create this PR to process the background only in the invert mode.

Please consider reviewing and merging it.

Thanks!