### PR TITLE
Fixed eaf-open-pdf-from-history, added eaf-pdf-extract-page-text and fixed reload issue

### DIFF
--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -517,17 +517,23 @@ This function works best if paired with a fuzzy search package."
                   "log.txt"))
          (history-pattern "^\\(.+\\)\\.pdf$")
          (history-file-exists (file-exists-p pdf-history-file-path))
+         (eaf-files-opened (mapcar (lambda (buf)
+                                     (buffer-local-value 'eaf--buffer-url buf))
+                                   (eaf--get-eaf-buffers)))
          (history-pdf (completing-read
                        "[EAF/pdf] Search || History: "
-                       (if history-file-exists
-                           (mapcar
-                            (lambda (h) (when (string-match history-pattern h)
-                                      (if (file-exists-p h)
-                                          (format "%s" h))))
-                            (with-temp-buffer (insert-file-contents pdf-history-file-path)
-                                              (split-string (buffer-string) "\n" t)))
-                         (make-directory (file-name-directory pdf-history-file-path) t)
-                         (with-temp-file pdf-history-file-path "")))))
+                       (cl-remove-if (lambda (x)
+                                       (or (null x)
+                                           (member x eaf-files-opened)))
+                                     (if history-file-exists
+                                         (mapcar
+                                          (lambda (h) (when (string-match history-pattern h)
+                                                        (if (file-exists-p h)
+                                                            (format "%s" h))))
+                                          (with-temp-buffer (insert-file-contents pdf-history-file-path)
+                                                            (split-string (buffer-string) "\n" t)))
+                                       (make-directory (file-name-directory pdf-history-file-path) t)
+                                       (with-temp-file pdf-history-file-path ""))))))
     (if history-pdf (eaf-open history-pdf))))
 
 (defun eaf-pdf-delete-invalid-file-record-from-history ()

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -731,6 +731,18 @@ This function works best if paired with a fuzzy search package."
          )
     (eaf-call-async "execute_function_with_args" eaf--buffer-id "edit_outline_confirm" payload)))
 
+(defun eaf-pdf-extract-page-text ()
+  "Display an PDF outline of the current buffer."
+  (interactive)
+  (let ((page-text-buffer (get-buffer-create (format "*Page text: %s*" (buffer-name))))
+        (page-text (eaf-call-sync "execute_function" eaf--buffer-id "get_page_text")))
+    (unless (string-empty-p page-text)
+      (with-current-buffer page-text-buffer
+        (erase-buffer)
+        (insert page-text)
+        (goto-char (point-min)))
+      (switch-to-buffer-other-window page-text-buffer))))
+
 ;;;; Register as module for EAF
 (add-to-list 'eaf-app-binding-alist '("pdf-viewer" . eaf-pdf-viewer-keybinding))
 

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -732,7 +732,7 @@ This function works best if paired with a fuzzy search package."
     (eaf-call-async "execute_function_with_args" eaf--buffer-id "edit_outline_confirm" payload)))
 
 (defun eaf-pdf-extract-page-text ()
-  "Display an PDF outline of the current buffer."
+  "Display the text of current page in a new buffer."
   (interactive)
   (let ((page-text-buffer (get-buffer-create (format "*Page text: %s*" (buffer-name))))
         (page-text (eaf-call-sync "execute_function" eaf--buffer-id "get_page_text")))

--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -354,6 +354,22 @@ class AppBuffer(Buffer):
             message_to_emacs("Move text annot: left-click mouse to choose a target position.")
             self.buffer_widget.annot_handler("move")
 
+    def edit_annot_by_id(self, page_index, annot_id):
+        page = self.buffer_widget.document[int(page_index)]
+        annot = self.buffer_widget.find_annot_by_id(page, annot_id)
+        self.buffer_widget.annot_handler("edit", annot)
+
+    def move_annot_by_id(self, page_index, annot_id):
+        message_to_emacs("Move text annot: left-click mouse to choose a target position.")
+        page = self.buffer_widget.document[int(page_index)]
+        annot = self.buffer_widget.find_annot_by_id(page, annot_id)
+        self.buffer_widget.annot_handler("move", annot)
+
+    def delete_annot_by_id(self, page_index, annot_id):
+        page = self.buffer_widget.document[int(page_index)]
+        annot = self.buffer_widget.find_annot_by_id(page, annot_id)
+        self.buffer_widget.annot_handler("delete", annot)
+
     def set_focus_text(self, new_text):
         import base64
         new_text = base64.b64decode(new_text).decode("utf-8")

--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -333,6 +333,9 @@ class AppBuffer(Buffer):
     def add_annot_inline_text(self):
         self.buffer_widget.enable_inline_text_annot_mode()
 
+    def add_annot_rect(self):
+        self.buffer_widget.enable_rect_annot_mode()
+
     def edit_annot_text(self):
         if self.buffer_widget.is_select_mode:
             atomic_edit(self.buffer_id, "")

--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -306,6 +306,11 @@ class AppBuffer(Buffer):
     def current_page(self):
         return str(self.buffer_widget.start_page_index + 1)
 
+    def get_page_text(self):
+        page_index = self.buffer_widget.current_page_index - 1
+        page = self.buffer_widget.document[page_index]
+        return page.get_text()
+
     def current_percent(self):
         return str(self.buffer_widget.current_percent())
 

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -258,7 +258,10 @@ class PdfViewerWidget(QWidget):
         # Register file watcher, when document is change, re-calling this function.
         self.document.watch_file(url, self.load_document)
 
-        self.update()
+        try:
+            self.update()
+        except Exception:
+            pass
 
     def is_buffer_focused(self):
         # This check is slow, use only when necessary

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -977,6 +977,8 @@ class PdfViewerWidget(QWidget):
                                               fontsize=self.inline_text_annot_fontsize,
                                               fontname="Arial",
                                               text_color=text_color, align=0)
+        elif (annot_action.annot_type == fitz.PDF_ANNOT_SQUARE):
+            new_annot = page.add_rect_annot(annot_action.annot_rect)
 
         if new_annot:
             new_annot.set_info(title=annot_action.annot_title)

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -258,10 +258,7 @@ class PdfViewerWidget(QWidget):
         # Register file watcher, when document is change, re-calling this function.
         self.document.watch_file(url, self.load_document)
 
-        try:
-            self.update()
-        except Exception:
-            pass
+        self.update()
 
     def is_buffer_focused(self):
         # This check is slow, use only when necessary

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -1403,10 +1403,10 @@ class PdfViewerWidget(QWidget):
         self.page_cache_pixmap_dict.clear()
         self.update()
 
-    def annot_handler(self, action=None):
-        if self.hovered_annot is None:
+    def annot_handler(self, action=None, annot=None):
+        annot = annot or self.hovered_annot
+        if annot is None:
             return
-        annot = self.hovered_annot
         if annot.parent:
             if action == "delete":
                 annot_action = AnnotAction.create_annot_action("Delete", annot.parent.number, annot)


### PR DESCRIPTION
Change 1: Removed "nil" and opened pdf files from eaf-open-pdf-from-history.
Change 2: Added eaf-pdf-extract-page-text to show text of current page in a new buffer.
Change 3: Fixed reload issue. It is mentioned in https://github.com/emacs-eaf/eaf-pdf-viewer/issues/98, but still exists in current version. After some digging, i think it's related to multi-thread. When i add some annotations on the pdf file, new thread is launched. Close it and reopen it, the annotation thread still exists but the widget related is destroyed. That's why the eaf_pdf_widget.py/load_document crashes at the "self.update()". I have no idea how to solve it thoroughly, so i wrapped it with "try-except", it's only a temporary solution but to make it usable.