### PR TITLE
add fast local line search interface and its ivy frontend

### DIFF
--- a/eaf_pdf_document.py
+++ b/eaf_pdf_document.py
@@ -162,3 +162,12 @@ class PdfDocument(fitz.Document):
 
     def watch_page_size_change(self, callback):
         self._document_page_change = callback
+
+    def build_reverse_index(self):
+        self.text_list = []
+        for i, page in enumerate(self):
+            text = page.get_text()
+            for line in text.split("\n"):
+                self.text_list.append(f"{i + 1}: {line}")
+        return "\n".join(self.text_list)
+            


### PR DESCRIPTION
The current search_text function is keyword-based and works well for small PDF files. However, when dealing with large PDFs (e.g., a 600+ page Emacs manual), iterating through the entire document to find all keywords becomes extremely slow. Searching in such a large document can cause Emacs to freeze for more than 10 seconds on my personal laptop running Ubuntu. While #104 introduced blink-search, it relies on external system tools like rga.

This commit introduces a new approach to improve search performance by adding an interface for local line-based search, without affecting the existing search functionality.

Here's how it works:

eaf-pdf-viewer first caches the text content and page indices of the PDF into a file.  Then the cached text is used with Emacs's minibuffer-based search tools (e.g., ivy or consult) , the selected line and its page index in the minibuffer are synchronized to the Python side to enable a local line search. 
The corresponding lines are highlighted in the PDF viewer, providing a seamless experience similar to searching in a regular Emacs buffer without repeatedly parsing the entire PDF using pymupdf. 

This commit also implements an ivy-based frontend for the local search interface. The design of the interface is modular, so other search tools like consult can also be easily implemented in the future.

showcase:
![2025-03-03_12-59-43](https://github.com/user-attachments/assets/7405773c-51e3-4d88-8397-85b9d31c93f2)

 instant fuzzy search in Emacs Manual (600+ pages)
