### PR TITLE
using string-equal instead of regexp matching.

### DIFF
--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -789,7 +789,7 @@ This function works best if paired with a fuzzy search package."
             ;; same cands in the same page
             (cl-remove-if-not
              (lambda (cand)
-               (string-match-p (cadr id-target) (cadr cand)))
+               (string= (cadr id-target) (cadr cand)))
              ids-cands))
            ;; index of current selected word in the page
            (current-index (cl-position id-target same-number-candidates :test 'equal)))
@@ -813,7 +813,7 @@ This function works best if paired with a fuzzy search package."
                        (ivy-state-current ivy-last)
                        ivy--index ivy--old-cands))
          :require-match t
-         :preselect current-page
+         :preselect (format "%s:" current-page)
          :action (lambda (selection) (eaf-pdf-narrow--done eaf-buffer-id))
          :unwind (lambda () (unless ivy-exit (eaf-pdf-narrow--quit eaf-buffer-id)))
          :caller 'eaf-pdf-narrow--ivy)

--- a/eaf_pdf_document.py
+++ b/eaf_pdf_document.py
@@ -168,6 +168,9 @@ class PdfDocument(fitz.Document):
         for i, page in enumerate(self):
             text = page.get_text()
             for line in text.split("\n"):
-                self.text_list.append(f"{i + 1}: {line}")
+                # more than 1 char
+                line = line.strip()
+                if len(line) > 1:
+                    self.text_list.append(f"{i + 1}: {line}")
         return "\n".join(self.text_list)
             

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -1090,8 +1090,8 @@ class PdfViewerWidget(QWidget):
 
     def search_text(self, text, page_num = None, page_offset=-1):
         self.is_mark_search = True
-        if page_num is not None: # clear spaces and soft hyphen in the line
-            text = text.strip(" -")
+        if page_num is not None: # clear soft hyphen in the line
+            text = text.strip("-")
         self.search_term = text
         self.last_search_term = text
         self.page_cache_pixmap_dict.clear()


### PR DESCRIPTION
When refining on #133, I find that it will generate errors when the search line contains special regex characters , since the PR have been merged, I open another one to address this.