### PR TITLE
make narrow-search work in epub files, add lazy caching

### DIFF
--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -833,8 +833,9 @@ This function works best if paired with a fuzzy search package."
          (n (length current-page-file-name))
          (cache-file-name (substring current-page-file-name start n)))
     (if (not (file-exists-p cache-file-name))
-        (message "Building %s ... or execute `eaf-pdf-rebuild-full-text-cache` to rebuild this cache file"
-                 cache-file-name)
+        (progn
+          (message "Building %s ...; \n You can execute `eaf-pdf-rebuild-full-text-cache` to rebuild this cache file when needed" cache-file-name)
+          (eaf-pdf-rebuild-full-text-cache))
       (cond
        ((require 'ivy nil 'noerror)
         ;; ivy style search

--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -78,9 +78,9 @@ class AppBuffer(Buffer):
 
         # Use thread to avoid slow down open speed.
         threading.Thread(target=self.record_open_history).start()
-
-        # Use thread to cache all text in pdf.
-        threading.Thread(target=self.cache_reverse_index).start()
+        
+        file_name = os.path.basename(self.url)
+        self.cache_file_name = os.path.join(get_emacs_config_dir(), "pdf", "cache", file_name + ".txt")
 
         self.build_all_methods(self.buffer_widget)
 
@@ -129,10 +129,12 @@ class AppBuffer(Buffer):
         """
         Cache all text in pdf to speed up search.
         """
+        # Use thread to cache all text in pdf.
+        threading.Thread(target=lambda : self._cache_reverse_index(True)).start()
+        
+    def _cache_reverse_index(self, force=False):
         # get file name from self.url
-        file_name = os.path.basename(self.url)
-        cache_file_name = os.path.join(get_emacs_config_dir(), "pdf", "cache", file_name + ".txt")
-        self.cache_file_name = cache_file_name
+        cache_file_name = self.cache_file_name
         txt_modified_time = os.path.getmtime(cache_file_name) if os.path.exists(cache_file_name) else 0
         pdf_modified_time = os.path.getmtime(self.url)
         if not force and pdf_modified_time <= txt_modified_time:

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -1087,11 +1087,20 @@ class PdfViewerWidget(QWidget):
                 self.search_page_history.add(page)
         return quads_list
 
+    def search_in_epub(self, page_num=None):
+        if page_num is not None and page_num >= 0:
+            self.jump_to_page(page_num+1)
+        else:
+            return # done
 
     def search_text(self, text, page_num = None, page_offset=-1):
+        if not self.document.is_pdf: # epub
+            self.search_in_epub(page_num)
+            return 
+            
         self.is_mark_search = True
         if page_num is not None: # clear soft hyphen in the line
-            text = text.strip("-")
+            text = text.strip(" -‐")
         self.search_term = text
         self.last_search_term = text
         self.page_cache_pixmap_dict.clear()


### PR DESCRIPTION
Narrow search now works in epub files with page following (line highlighting is not supported because pymupdf's annotations can only be inserted in PDF pages).

Also, index caching is now triggered when narrow-search command is executed for the first time, so it will not generate any cache files for users who never use this feature.