### PR TITLE
draw arrow indicator when narrow-search in epub

### DIFF
--- a/eaf_pdf_page.py
+++ b/eaf_pdf_page.py
@@ -86,7 +86,6 @@ class PdfPage(fitz.Page):
 
         self.has_annot = page.first_annot
         self.hovered_annot = None
-        self._current_match_color = QColor("#f28100").getRgbF()[0:3]
 
     def __getattr__(self, attr):
         return getattr(self.page, attr)
@@ -345,7 +344,8 @@ class PdfPage(fitz.Page):
                 annot = self.page.add_highlight_annot(quads)
                 annot.parent = self.page
                 if quads == current_quads:
-                    annot.set_colors(stroke=self._current_match_color)
+                    qcolor = QColor("#f28100")
+                    annot.set_colors(stroke=qcolor.getRgbF()[0:3])
                     annot.update()
                 self._mark_search_annot_list.append(annot)
 

--- a/eaf_pdf_page.py
+++ b/eaf_pdf_page.py
@@ -86,6 +86,7 @@ class PdfPage(fitz.Page):
 
         self.has_annot = page.first_annot
         self.hovered_annot = None
+        self._current_match_color = QColor("#f28100").getRgbF()[0:3]
 
     def __getattr__(self, attr):
         return getattr(self.page, attr)
@@ -330,6 +331,10 @@ class PdfPage(fitz.Page):
     def mark_search_text(self, keyword, current_quads):
         self.cleanup_search_text()
 
+        if not self.is_pdf:
+            # add_highlight_annot is only for pdf
+            return 
+        
         if support_hit_max:
             quads_list = self.page.searchFor(keyword, hit_max=999, quads=True)
         else:
@@ -340,8 +345,7 @@ class PdfPage(fitz.Page):
                 annot = self.page.add_highlight_annot(quads)
                 annot.parent = self.page
                 if quads == current_quads:
-                    qcolor = QColor("#f28100")
-                    annot.set_colors(stroke=qcolor.getRgbF()[0:3])
+                    annot.set_colors(stroke=self._current_match_color)
                     annot.update()
                 self._mark_search_annot_list.append(annot)
 

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -514,6 +514,15 @@ class PdfViewerWidget(QWidget):
         painter.setFont(self.font)    # type: ignore
         painter.setPen(QColor(self.get_render_foreground_color()))
         self.update_page_progress(painter)
+        
+        if self.is_mark_search and not self.document.is_pdf and self.current_search_quads and self.current_search_page:
+            x0, y0, x1, y1 = self.current_search_quads.rect
+            page_offset = self.scroll_offset - (self.current_search_page) * self.scale * self.page_height
+            
+            x, y = (x0 - 10 + self.page_render_x/2) * self.scale, y1 * self.scale-page_offset
+            # print(self.current_search_quads.rect)
+            # pos = QPoint(x, y)
+            self.draw_arrow_indicator(painter, int(x), int(y)-3)
 
     def draw_presentation_page(self, painter, index):
         # Get page render information.
@@ -1087,20 +1096,11 @@ class PdfViewerWidget(QWidget):
                 self.search_page_history.add(page)
         return quads_list
 
-    def search_in_epub(self, page_num=None):
-        if page_num is not None and page_num >= 0:
-            self.jump_to_page(page_num+1)
-        else:
-            return # done
-
     def search_text(self, text, page_num = None, page_offset=-1):
-        if not self.document.is_pdf: # epub
-            self.search_in_epub(page_num)
-            return 
-            
         self.is_mark_search = True
         if page_num is not None: # clear soft hyphen in the line
             text = text.strip(" -‐")
+        self.current_search_page = page_num
         self.search_term = text
         self.last_search_term = text
         self.page_cache_pixmap_dict.clear()


### PR DESCRIPTION
thanks for  `draw_arrow_indicator` function, we can use it to show arrow indicator when performing narrow-search in epub file(because annotation is only for PDF in pymupdf)