### PR TITLE
make page synchronizing in outline buffer  precise and use integer as Qfont size

### DIFF
--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -317,6 +317,14 @@ Non-nil means don't invert images."
               (buffer-name pdf-buffer)
             pdf-buffer)))
 
+(defun eaf-pdf--open-outline-buffer (outline-buffer page-number)
+  "open outline buffer and sync to page number"
+  (pop-to-buffer outline-buffer)
+  (setq toc (mapcar #'(lambda (line)
+                        (string-to-number (car (last (split-string line " ")))))
+                    (butlast (split-string (buffer-string) "\n"))))
+  (goto-line (seq-count (apply-partially #'>= page-number) toc)))
+
 (defun eaf-pdf-outline ()
   "Display an PDF outline of the current buffer."
   (interactive)
@@ -332,17 +340,13 @@ Non-nil means don't invert images."
       (setq buffer-read-only nil)
       (erase-buffer)
       (insert toc)
-      (setq toc (mapcar #'(lambda (line)
-                            (string-to-number (car (last (split-string line " ")))))
-                        (butlast (split-string (buffer-string) "\n"))))
-      (goto-line (seq-count (apply-partially #'>= page-number) toc))
       (let ((view-read-only nil))
         (read-only-mode 1))
       (eaf-pdf-outline-mode)
       (setq-local eaf-pdf-outline-pdf-document pdf-buffer))
 
     ;; Popup outline buffer.
-    (pop-to-buffer outline-buf)))
+    (eaf-pdf--open-outline-buffer outline-buf page-number)))
 
 (defun eaf-pdf-outline-edit ()
   (interactive)
@@ -350,25 +354,17 @@ Non-nil means don't invert images."
          (buffer-id (buffer-local-value 'eaf--buffer-id (get-buffer pdf-buffer)))
          (toc (eaf-call-sync "execute_function" buffer-id "get_toc_to_edit"))
          (page-number (string-to-number (or (eaf-call-sync "execute_function" eaf--buffer-id "current_page") "1")))
-         (outline-edit-buffer-name (eaf-pdf-outline-edit-buffer-name)))
+         (outline-buf (get-buffer-create (eaf-pdf-outline-edit-buffer-name))))
     
-    ;; if buffer-name is already in use, just split the window and use the existing buffer
-    (if (get-buffer outline-edit-buffer-name)
-        (switch-to-buffer-other-window outline-edit-buffer-name)
-      (let ((outline-edit-buffer (generate-new-buffer outline-edit-buffer-name)))
-        ;; Insert outline content.
-      (with-current-buffer outline-edit-buffer
-        (setq buffer-read-only nil)
-        (erase-buffer)
-        (insert toc)
-        (setq toc (mapcar #'(lambda (line)
-                              (string-to-number (car (last (split-string line " ")))))
-                          (butlast (split-string (buffer-string) "\n"))))
-        (goto-line (seq-count (apply-partially #'>= page-number) toc))
-        (eaf-pdf-outline-edit-mode)
-        (set (make-local-variable 'eaf--buffer-id) buffer-id)
-        )
-        (pop-to-buffer outline-edit-buffer)))))
+    ;; Insert outline content.
+    (with-current-buffer outline-buf
+      (setq buffer-read-only nil)
+      (erase-buffer)
+      (insert toc)
+      (eaf-pdf-outline-edit-mode)
+      (set (make-local-variable 'eaf--buffer-id) buffer-id))
+
+    (eaf-pdf--open-outline-buffer outline-buf page-number)))
 
 (defun eaf-pdf-outline-jump ()
   "Jump into specific page."

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -673,8 +673,8 @@ class PdfViewerWidget(QWidget):
 
 
             scaling_ratio = self.page_render_width / self.rect().width()
-            progress_font_size = max(int(self.font_size * (1 - math.cos(scaling_ratio * math.pi)) / 2), 0.1)
-            painter.setFont(QFont(self.font.family(), progress_font_size))
+            progress_font_size = max(int(self.font_size * (1 - math.cos(scaling_ratio * math.pi)) / 2), 1)
+            painter.setFont(QFont(self.font.family(), int(progress_font_size)))
             painter.drawText(progress_rect,
                              Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignBottom,
                              self.get_page_progress())


### PR DESCRIPTION
## Commit 1: Fix page number synchronization issue when opening outline

After opening an outline or outline-edit buffer, subsequent calls to eaf-pdf-outline-edit or eaf-pdf-outline-edit fail to synchronize the page number. Specifically, `(goto-line (seq-count (apply-partially #'>= page-number) toc))` does not effectively move the cursor to the correct line.

I suspect that it is the `pop-to-buffer` function resets the cursor position to the beginning of the buffer after displaying it. 

So this commit moves the page synchronization logic (i.e., the `(goto-line ...)` call)  after pop-to-buffer, ensuring that page synchronization occurs after the buffer is displayed and the cursor position is settled 
#
## Commit 2: Ensure font size is an integer for compatibility with specific PyQt6 versions

Certain versions of PyQt6 (e.g., 6.5.0) require the font size for QFont to be an integer type. Passing a non-integer font size to QFont in these versions will raise an error.