### PR TITLE
 introduces `mark_position` and `toggle_last_position` (bound to C-t) to enhance navigation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,4 @@ Override this behavior
 | `o` | eaf-pdf-outline |
 | `O` | eaf-pdf-outline-edit |
 | `T` | toggle_trim_white_margin |
+| `C-t` | toggle_last_position |

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -206,7 +206,8 @@ Non-nil means don't invert images."
     ("K" . "select_right_tab")
     ("o" . "eaf-pdf-outline")
     ("O" . "eaf-pdf-outline-edit")
-    ("T" . "toggle_trim_white_margin"))
+    ("T" . "toggle_trim_white_margin")
+    ("C-t" . "toggle_last_position"))
   "The keybinding of EAF PDF Viewer."
   :type '(alist :key-type (string :tag "Key bindings (e.g. \"C-n\", \"<f4>\", etc.)")
                 :value-type (string :tag "Function name"))

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -858,10 +858,12 @@ class PdfViewerWidget(QWidget):
 
     @interactive
     def scroll_to_begin(self):
+        self.buffer.mark_position()
         self.update_vertical_offset(0)    # type: ignore
 
     @interactive
     def scroll_to_end(self):
+        self.buffer.mark_position()
         self.update_vertical_offset(self.max_scroll_offset())    # type: ignore
 
     @interactive
@@ -1052,6 +1054,7 @@ class PdfViewerWidget(QWidget):
         if "page" in link:
             self.cleanup_links()
             self.save_current_pos()
+            self.buffer.mark_position()
 
             target_point = link["to"]
             offset_y_from_top = self.page_height - target_point.y
@@ -1528,6 +1531,7 @@ class PdfViewerWidget(QWidget):
         return current_link
 
     def jump_to_page(self, page_num, pos_y=None):
+        self.buffer.mark_position()
         page_nume = int(page_num) - 1
         page_offset = max(self.scale * page_nume * self.page_height, 0)
         if pos_y == None:


### PR DESCRIPTION
To improve ease of navigation, this commit introduces `mark_position` and `toggle_last_position`(bound to C-t). 

 Currently, there isn't an automatic mechanism to remember the position before a long excursion, such as goto the first or last page  on purpose or by accident, jumping to a specific page, or searching for keywords on other pages. While  `save_current_pos` and `jump_to_saved_pos` are used before link jumping, in other scenario, they must be called manually and may add a lot of position markers into the `saved_pos_sequence` list which is more like a bookmark, making it messy. 