### PR TITLE
For both PDF and EPUB: double-click for text extraction and sync when synctex failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,8 @@ Override this behavior
 | `O` | eaf-pdf-outline-edit |
 | `T` | toggle_trim_white_margin |
 | `C-t` | toggle_last_position |
+
+### Other Features
+
+- `eaf-pdf-narrow-search`: full-document line-based search and live-preview with ivy (for both PDF and EPUB)
+- left double click: open an emacs buffer filled with text of current page and jump to the corresponding line. (for EPUB and PDF when synctex failed)

--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -358,8 +358,8 @@ class AppBuffer(Buffer):
     def current_page(self):
         return str(self.buffer_widget.start_page_index + 1)
 
-    def get_page_text(self):
-        page_index = self.buffer_widget.current_page_index - 1
+    def get_page_text(self, page_index=None):
+        page_index = page_index if page_index is not None else self.buffer_widget.current_page_index - 1
         page = self.buffer_widget.document[page_index]
         return page.get_text()
 


### PR DESCRIPTION
Currently , left double-click is primarily used for LaTeX backward synchronization. this is not the typical use case for  PDF and EPUB viewers (sync back to TeX is even invalid for EPUB files). Most of the time, users simply open downloaded PDF or EPUB files to read without the corresponding LaTeX source code.

So, this commit makes double click more useful: if it is not within a Latex project folder (without *.synctex.gz file or synctex failes) , or it is an EPUB file, a left double-click will call  `eaf-pdf-extract-page-text` to open an emacs buffer with text of current page and jump to the text section under the cursor (roughly), then we can copy or edit the content with emacs keybindings.

This behavior aligns with the LaTeX synchronization mechanism, we lose nothing but get a much more powerful click!