### PR TITLE
add Customization entry for progress font size

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Override this behavior
 | `T` | toggle_trim_white_margin |
 | `C-t` | toggle_last_position |
 
-### Other Features
+### Other Features and Customization
 
 - `(eaf-pdf-narrow-search)`: full-document line-based search and live-preview with ivy (for both PDF and EPUB)
 - `(eaf-pdf-narrow-search "toc")`: search toc with ivy (for both PDF and EPUB)
@@ -121,3 +121,11 @@ Override this behavior
     (eaf-bind-key eaf-pdf-narrow-search "/" eaf-pdf-viewer-keybinding)
   ```
 - left double click: open an emacs buffer filled with text of current page and jump to the corresponding line. (for EPUB and PDF when synctex failed)
+
+- set progress bar font size lively
+```Elisp
+  (setq eaf-pdf-show-progress-on-page 't) ;; default 24
+  (setq eaf-pdf-show-progress-on-page nil) ;; hide progress bar
+  (setq eaf-pdf-show-progress-on-page 20) ;; set font size to 20
+  (setq eaf-pdf-show-progress-on-page 0) ;; hide progress bar
+```

--- a/eaf-pdf-viewer.el
+++ b/eaf-pdf-viewer.el
@@ -84,8 +84,11 @@
   :group 'eaf-pdf-viewer)
 
 (defcustom eaf-pdf-show-progress-on-page t
-  "If it is t, pdf-viewer will show progress (in percentage) and page number directly on the document."
-  :type 'boolean
+  "If it is t, pdf-viewer will show progress (in percentage) and page number directly on the document.
+  if it is an integer, it will be used as the font size of the progress. 0 means no progress.
+  "
+  :type '(choice (boolean :tag "Show progress on page" t)
+                 (integer :tag "Font size of progress on page" 0))
   :group 'eaf-pdf-viewer)
 
 (defcustom eaf-pdf-dark-mode "ignore"

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -194,10 +194,7 @@ class PdfViewerWidget(QWidget):
         self.page_annotate_padding_x = 10
         self.page_annotate_padding_y = 10
 
-        self.font = QFont()    # type: ignore
-        self.font_size = 24
-        self.font.setPointSize(self.font_size)
-
+        self.default_progress_font_size = 24
         # Page cache.
         self.page_cache_pixmap_dict = {}
         self.page_cache_scale = self.scale
@@ -512,8 +509,7 @@ class PdfViewerWidget(QWidget):
         # Restore painter.
         painter.restore()
 
-        # Render progress information.
-        painter.setFont(self.font)    # type: ignore
+        # Render progress information.  # type: ignore
         painter.setPen(QColor(self.get_render_foreground_color()))
         self.update_page_progress(painter)
         
@@ -672,11 +668,14 @@ class PdfViewerWidget(QWidget):
                                   int(self.rect().y() + self.page_annotate_padding_y),
                                   int(self.page_render_width - self.page_annotate_padding_x * 2),
                                   int(self.rect().height() - self.page_annotate_padding_y * 2))
-
-
+            base_progress_font_size = self.default_progress_font_size
+            if type(show_progress_on_page) == int:
+                base_progress_font_size = show_progress_on_page
             scaling_ratio = self.page_render_width / self.rect().width()
-            progress_font_size = max(int(self.font_size * (1 - math.cos(scaling_ratio * math.pi)) / 2), 1)
-            painter.setFont(QFont(self.font.family(), int(progress_font_size)))
+            progress_font_size = max(int(base_progress_font_size * (1 - math.cos(scaling_ratio * math.pi)) / 2), 1)
+            progress_font = QFont()
+            progress_font.setPixelSize(progress_font_size)
+            painter.setFont(progress_font)
             painter.drawText(progress_rect,
                              Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignBottom,
                              self.get_page_progress())


### PR DESCRIPTION
Somethings the font of progress bar is too big, so I think it is better to provide an entry for users to customize this variable,  we can overwrite  `eaf-pdf-show-progress-on-page` to set the font size of the progress bar.
