### PR TITLE
refactor progress font size and position calculation for improved rendering

### DIFF
--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -673,12 +673,8 @@ class PdfViewerWidget(QWidget):
             if type(show_progress_on_page) == int:
                 base_progress_font_size = show_progress_on_page
             
-            render_window_ratio = self.page_render_width / self.rect().width()
-            if render_window_ratio < 1:
-                scaling_factor = self.scale
-            else:
-                scaling_factor = round(self.scale / render_window_ratio, 2)
-            progress_font_size = int((1-0.6*math.exp(-1.5*(scaling_factor-1))) * base_progress_font_size)
+
+            progress_font_size = int((1-0.6*math.exp(-1.5*(self.scale-1))) * base_progress_font_size)
             progress_font = QFont()
             progress_font.setPixelSize(progress_font_size)
             painter.setFont(progress_font)


### PR DESCRIPTION
There are two small bugs in progress bar font rendering

The first issue is that when zooming in on the document, the progress text extends beyond the Emacs window border, as shown below:
![2025-04-03_21-52-25](https://github.com/user-attachments/assets/5784ff0a-f3ed-4223-a0a0-eae7b590bf14)


After I fix the positioning of the progress bar and zoomed in further, a second problem arose. The font size of the progress becomes smaller when the `page_render_width` is greater than the emacs window width because of the periodical property of `cos(x) ` function:
![2025-04-03_21-54-16](https://github.com/user-attachments/assets/14a0c39e-0afb-43f4-a358-22680811f3f6)


So I ask AI to recommend a function for better font scaling, it give me function like this:
![Screenshot from 2025-04-03 21-43-43](https://github.com/user-attachments/assets/779ad010-2c99-4aaa-b49f-396a5a981260)

the font size wiil be bounded between  0.4*default_progress_font_size and default_progress_font_size (this can be customized by user due to last PR),  I tested it and feel satisfied, hope you like it too
