### PR TITLE
search_text boost up

### DIFF
--- a/eaf_pdf_page.py
+++ b/eaf_pdf_page.py
@@ -348,13 +348,14 @@ class PdfPage(fitz.Page):
                     annot.set_colors(stroke=qcolor.getRgbF()[0:3])
                     annot.update()
                 self._mark_search_annot_list.append(annot)
+            return self._mark_search_annot_list
 
     def cleanup_search_text(self):
         if self._mark_search_annot_list:
             # message_to_emacs("Unmarked all matched results.")
             for annot in self._mark_search_annot_list:
                 self.page.delete_annot(annot)
-            self._mark_search_annot_list = []
+            self._mark_search_annot_list.clear()
 
     def mark_jump_link_tips(self, letters):
         fontsize, = get_emacs_vars(["eaf-pdf-marker-fontsize"])


### PR DESCRIPTION
There are two major bottlenecks in the current keyword-based text search functionality:
1. Excessive Search Triggers: The `send_input_message` function monitors user typing in every 0.1 second. Consequently, nearly every keystroke sends a signal  to `AppBuffer.handle_input_response`, triggering a full text search, For instance, when searching for "debug", this results in five separate search processes being executed for "d", "de", "deb", "debu", and "debug" which is not what we expected. To address this, the first commit introduces a debouncing mechanism to regulate the signal stream.

2. Inefficient Page Iteration: During the process of iterating through all pages for searching, the code uses `page = self.document[page_index]` to retrieve each page. Both  `self.document`(`PdfDocument`) and `page`(`PdfPage`) are wrappers around the original document and  page objects in pymupdf.  During the initialization of PdfPage ,  `_init_page_rawdict` and  `_init_page_char_rect_list`  are called to extract all the geometic properties of objects in the pdf,  these properties are essential for rendering and enhanced interactivity, they consume significant time and are unnecessary for text-only searches. Therefore, the second commit optimizes this by skipping the PdfPage wrapper and directly accessing the raw page for search operations.


with these refactors, the time taken to searching keyword `debugging`  in the Elisp manual (1300+ page) can be reduced from 40+ seconds to 2~3 seconds, this is a huge improvement.

by the way, these two issue had been pointed out by @hitswint in:
https://emacs-china.org/t/eaf-pdf-viewer-pdf-epub/29253/10
and 
https://emacs-china.org/t/eaf-pdf-viewer-pdf-epub/29253/17