### PR TITLE
robust search clean up

### DIFF
--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -353,11 +353,9 @@ class AppBuffer(Buffer):
             # return page num and search target file path
             return f"{self.current_page()} {self.cache_file_name}"
         elif pages == -2: # -2 : jump to target page
-            self.buffer_widget.search_text("", pages, index) # cleanup highlights
             self.buffer_widget.cleanup_search()  # search done
         elif pages == -1: # -1 as search quit signal
             self.toggle_last_position()
-            self.buffer_widget.search_text("", pages, index) # cleanup highlights
             self.buffer_widget.cleanup_search()
         elif search_term == "":
             return  # at least one char for search

--- a/eaf_pdf_page.py
+++ b/eaf_pdf_page.py
@@ -326,13 +326,11 @@ class PdfPage(fitz.Page):
             for annot in self._mark_link_annot_list:
                 self.page.delete_annot(annot)
             self._mark_link_annot_list = []
-
+            
     def mark_search_text(self, keyword, current_quads):
-        self.cleanup_search_text()
-
         if not self.is_pdf:
             # add_highlight_annot is only for pdf
-            return 
+            return []
         
         if support_hit_max:
             quads_list = self.page.searchFor(keyword, hit_max=999, quads=True)
@@ -349,13 +347,13 @@ class PdfPage(fitz.Page):
                     annot.update()
                 self._mark_search_annot_list.append(annot)
             return self._mark_search_annot_list
+        return []
 
-    def cleanup_search_text(self):
-        if self._mark_search_annot_list:
-            # message_to_emacs("Unmarked all matched results.")
-            for annot in self._mark_search_annot_list:
-                self.page.delete_annot(annot)
-            self._mark_search_annot_list.clear()
+    def cleanup_search_text(self, old_annots):
+        annots = set(self._mark_search_annot_list) | set(old_annots)
+        for annot in annots:
+            self.page.delete_annot(annot)
+        self._mark_search_annot_list.clear()
 
     def mark_jump_link_tips(self, letters):
         fontsize, = get_emacs_vars(["eaf-pdf-marker-fontsize"])


### PR DESCRIPTION
Fix search text cleanup bugs when revisiting a page multiple times  or do progressive search in one search session.

Explanation:
1. Search for a word (e.g., "debug") in a PDF document. Observe that the search highlights are displayed.
2. Keep the highlights visible and use the mouse wheel to scroll several pages away (e.g., four or more):
3. Scroll back to the page where you initially searched.  `page.mark_search_text(self.search_term, self.current_search_quads)` will draw multiple annots on the same quads(you can observe the annot become darker as the revieted count increases, or quit the search to see that highlights are still there). Because each time the page is rendered, `page` is a new instance of PdfPage in which `_mark_search_annot_list` is an empty  list, PdfPage.cleanup_search_text could not clean the old annots. So we should pass the annot history(variable: `rendered_searched_quads`) to PdfPage for  cleanup.
4.  While still in search mode, begin typing more characters to search for a long word (e.g., "debugging"), then scroll to  other pages and quit search.
5. Scroll back to the page where you initially searched, the highlights for "debug" will not be cleared. This is because current code didn't clean the annot of previouse search term in unvisible pages (although it did a cleanup on visible pages), so every time before search, we should do a full cleanup.