### PR TITLE
improve search text debounce timing by adding character-based delay

### DIFF
--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -80,7 +80,8 @@ class SearchAdapter(QObject):
         
     def search_text(self, search_term):
         self.current_search_term = search_term
-        dynamic_delay = self.search_delay 
+        char_delay = 0.8/len(search_term) if len(search_term) > 0 else 0
+        dynamic_delay = self.search_delay + char_delay
 
         self.debounce_timer.stop()
         self.debounce_timer.start(int(dynamic_delay * 1000))


### PR DESCRIPTION
short words can increase search time and are often just prefixes of the complete search query, so it is reasonable to add a longer delay to wait more user input.