### PR TITLE
efficient text selection

### DIFF
--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -387,14 +387,14 @@ class AppBuffer(Buffer):
 
     def copy_select(self):
         if self.buffer_widget.is_select_mode:
-            content = self.buffer_widget.parse_select_char_list()
+            content = self.buffer_widget.parse_select_obj_list()
             eval_in_emacs('kill-new', [content])
             message_to_emacs(content)
             self.buffer_widget.cleanup_select()
 
     def get_select(self):
         if self.buffer_widget.is_select_mode:
-            content = self.buffer_widget.parse_select_char_list()
+            content = self.buffer_widget.parse_select_obj_list()
             self.buffer_widget.cleanup_select()
             return content
         else:

--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -142,8 +142,6 @@ class AppBuffer(Buffer):
 
         self.build_all_methods(self.buffer_widget)
         self.search_adapter = SearchAdapter(self.buffer_widget)
-        
-        self.last_percentage = -1
 
         # Convert title if pdf is converted from office file.
         if arguments.endswith("_office_pdf"):
@@ -224,13 +222,13 @@ class AppBuffer(Buffer):
     @PostGui()
     def handle_input_response(self, callback_tag, result_content):
         if callback_tag == "jump_page":
-            self.mark_position()
+            self.buffer_widget.mark_position()
             self.buffer_widget.jump_to_page(int(result_content))
         elif callback_tag == "jump_percent":
-            self.mark_position()
+            self.buffer_widget.mark_position()
             self.buffer_widget.jump_to_percent(int(result_content))
         elif callback_tag == "jump_link":
-            self.buffer_widget.jump_to_link(str(result_content))
+            self.buffer_widget.buffer_widget.jump_to_link(str(result_content))
         elif callback_tag == "search_text":
             self.search_adapter.search_text(str(result_content))
 
@@ -318,6 +316,10 @@ class AppBuffer(Buffer):
 
     def jump_to_percent(self):
         self.send_input_message("Jump to Percent: ", "jump_percent")
+        
+    def toggle_last_position(self):
+        self.buffer_widget.toggle_last_position()
+        return ""
 
     def jump_to_percent_with_num(self, percent):
         self.buffer_widget.jump_to_percent(float(percent))
@@ -338,25 +340,16 @@ class AppBuffer(Buffer):
             self.buffer_widget.cleanup_links()
         if self.buffer_widget.is_select_mode:
             self.buffer_widget.cleanup_select()
-            
-    def mark_position(self, percentage=-1):
-        self.last_percentage = percentage if percentage != -1 else self.buffer_widget.current_percent()
-        
-    def toggle_last_position(self):
-        if self.last_percentage != -1:
-            last_percentage = self.last_percentage
-            self.mark_position()
-            self.buffer_widget.jump_to_percent(last_percentage) 
 
     def narrow_search_protocol(self, search_term="", pages=None, index=None):
         if pages == -3: # -3 as search begin signal
-            self.mark_position()
+            self.buffer_widget.mark_position()
             # return page num and search target file path
             return f"{self.current_page()} {self.cache_file_name}"
         elif pages == -2: # -2 : jump to target page
             self.buffer_widget.cleanup_search()  # search done
         elif pages == -1: # -1 as search quit signal
-            self.toggle_last_position()
+            self.buffer_widget.toggle_last_position()
             self.buffer_widget.cleanup_search()
         elif search_term == "":
             return  # at least one char for search

--- a/eaf_pdf_widget.py
+++ b/eaf_pdf_widget.py
@@ -209,6 +209,7 @@ class PdfViewerWidget(QWidget):
         self.saved_pos_sequence = []
         self.saved_pos_index = -1
         self.remember_offset = None
+        self.last_percentage = -1
 
         self.start_page_index = 0
         self.start_page_index_before_presentation = 0
@@ -853,6 +854,15 @@ class PdfViewerWidget(QWidget):
         if self.start_page_index > 0:
             self.start_page_index = self.start_page_index - 1
             self.update()
+            
+    def mark_position(self, percentage=-1):
+        self.last_percentage = percentage if percentage != -1 else self.current_percent()
+        
+    def toggle_last_position(self):
+        if self.last_percentage != -1:
+            last_percentage = self.last_percentage
+            self.mark_position()
+            self.jump_to_percent(last_percentage) 
 
     @interactive
     def scroll_up(self):
@@ -898,12 +908,12 @@ class PdfViewerWidget(QWidget):
 
     @interactive
     def scroll_to_begin(self):
-        self.buffer.mark_position()
+        self.mark_position()
         self.update_vertical_offset(0)    # type: ignore
 
     @interactive
     def scroll_to_end(self):
-        self.buffer.mark_position()
+        self.mark_position()
         self.update_vertical_offset(self.max_scroll_offset())    # type: ignore
 
     @interactive
@@ -1094,7 +1104,7 @@ class PdfViewerWidget(QWidget):
         if "page" in link:
             self.cleanup_links()
             self.save_current_pos()
-            self.buffer.mark_position()
+            self.mark_position()
 
             target_point = link["to"]
             page_y_from_top = self.page_height - target_point.y if self.document.is_pdf else target_point.y


### PR DESCRIPTION
The current text selection algorithm  needs to flatten the raw_dict from pymupdf page, drawing each quad of characters one by one which is slow , This commit utilizes the tree structure to avoid this overhead and merges more quads to  reduce the drawing cost, improving the fluency and smoothness.