### PR TITLE
some performance opitimization

### DIFF
--- a/eaf_pdf_buffer.py
+++ b/eaf_pdf_buffer.py
@@ -386,19 +386,14 @@ class AppBuffer(Buffer):
             self.edit_annot_text()
 
     def copy_select(self):
-        if self.buffer_widget.is_select_mode:
-            content = self.buffer_widget.parse_select_obj_list()
+        content = self.buffer_widget.get_select()
+        if content:
             eval_in_emacs('kill-new', [content])
             message_to_emacs(content)
-            self.buffer_widget.cleanup_select()
+            # message_to_emacs(f"Copied: {content[:20]}...{content[-20:]}") # maybe customize
 
     def get_select(self):
-        if self.buffer_widget.is_select_mode:
-            content = self.buffer_widget.parse_select_obj_list()
-            self.buffer_widget.cleanup_select()
-            return content
-        else:
-            return ""
+        return self.buffer_widget.get_select()
 
     def page_total_number(self):
         return str(self.buffer_widget.page_total_number)


### PR DESCRIPTION
Improve page rendering and mouse hover/selection performance by:

- Removing redundant background drawing (we don't need to draw background  on every patinEvent if we set the background of full widget correctly,  drawing a small padding gap rect then is more efficient).
- the fitz.Rect().intersects and contain functions are really slow,  replacing them with simple coordinate comparisons methods, it makes text selection more smooth
-   cache  page links  and annots on page initialization

the commit also contains some code refactors  for better readability 
