### PR TITLE
fix text selection missing and shape of hover cursor problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,6 @@ Override this behavior
   (setq eaf-pdf-show-progress-on-page 0) ;; hide progress bar
 ```
 
-- change cursor selection color
-```Elisp
-  (setq eaf-pdf-text-highlight-annot-color "#fa8500") # ;; default #ffd815
-```
-
 - click after select to copy text
 ```Elisp
   (setq eaf-pdf-click-to-copy t) # ;; default nil


### PR DESCRIPTION
there are two remain issues related to text selection:
- when the backgound of text is not the same as the page background, both `QPainter.CompositionMode.CompositionMode_SourceAtop` and `QPainter.CompositionMode.CompositionMode_DestinationAtop` failed, the highlight color is invisible, so this commit use  `CompositionMode_SourceOver` with a fixed transparent highlight color (We don't need to provide a user customization option, because choosing a color with transparency can be difficult.)
-  the problem/solution mentioned in https://github.com/pymupdf/PyMuPDF/issues/4322 

Also, the logic for updating the cursor on mouse hover has been clarified.